### PR TITLE
Fix api version

### DIFF
--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ function released(type, obj) {
 }
 
 function releasedWatch() {
-  const path = '/apis/apps/v1beta1/deployments';
+  const path = '/apis/apps/v1/deployments';
   (new Watch(kc)).watchNew(path, { includeUninitialized: false }, released, done.bind(null, 'releases', releasedWatch));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/watch.js
+++ b/watch.js
@@ -57,7 +57,7 @@ class Watch {
       if (obj.type && obj.object) {
         callback(obj.type, obj.object);
       } else {
-        console.log(`unexpected object: ${obj}`);
+        console.log(`unexpected object: ${JSON.stringify(obj)}`);
       }
     });
 


### PR DESCRIPTION
Use `v1` instead of `v1beta`
Stringify unexpected results from k8s for debugging purposes