### PR TITLE
Fix releases being triggered when a node is deleted

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "no-console": "off",
     "max-len": [
       "warn", 
-      { "code": 125, "ignoreUrls": true }
+      { "code": 140, "ignoreUrls": true }
     ],
     "no-param-reassign": "off"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -340,6 +340,14 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -890,6 +898,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@kubernetes/client-node": "^0.10.2",
+    "axios": "^0.21.1",
     "byline": "^5.0.0",
     "node-vault": "^0.9.13",
     "request": "^2.88.0"


### PR DESCRIPTION
The apps-watcher would send an erroneous `released` event for certain apps during a node deletion if the following conditions were met:
- The apps-watcher had not seen a release for the app yet
- The app was moved as part of the rebalancing

When the apps-watcher processed the deployment change for the moved app under these conditions, it would think it was a new release since the UUID wasn't in the cache and all the other conditions were met.

To fix this, the apps-watcher now stores every release UUID in the cache upon starting. It uses the `as=Table;v=v1beta1;g=meta.k8s.io` parameters in the content type to speed up the request (much faster/smaller payload to retrieve only metadata rather than the whole deployment object for each of the 1500+ deployments).

Also fixed in this PR is that the apps-watcher now ignores any incoming object without the `akkeris.io/app-name` label when processing crashed event candidates. This will stop crashed events being sent to the controller for non Akkeris deployments.