### PR TITLE
Add all CA cert files to the https globalAgent

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,15 @@ async function loadFromCluster() {
   console.log('\nIn-cluster mode: Connecting to default Kubernetes cluster...');
   try {
     kc.loadFromCluster();
+
+    // Load CAs from each cluster into the https globalAgent
+    // There really should only be one cluster but better safe than sorry
+    const cas = kc.clusters.map((cluster) => cluster.caFile);
+    https.globalAgent.options.ca = [];
+    cas.forEach((ca) => {
+      https.globalAgent.options.ca.push(fs.readFileSync(ca));
+    });
+
     await checkPermissions();
   } catch (err) {
     console.log('\nIn-cluster loading failed with the following message:\n', err.message);


### PR DESCRIPTION
For some reason that I'm still investigating, we started seeing `UNABLE_TO_VERIFY_LEAF_SIGNATURE` errors when attempting to cache current deployments by making an https request to the `kube-apiserver` (through `axios`). The cluster CA was being added to the request by the k8s client `applyToRequest` function, but that suddenly stopped being enough I guess?

In any case, it appears that adding the CA cert to the `https.globalAgent.options.ca` array fixes the issue.