### PR TITLE
add default root certificates to request

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const vault = require('node-vault');
 const url = require('url');
 const http = require('http');
 const https = require('https');
+const tls = require('tls');
 const assert = require('assert');
 const fs = require('fs');
 const axios = require('axios');
@@ -83,7 +84,7 @@ async function loadFromCluster() {
     // Load CAs from each cluster into the https globalAgent
     // There really should only be one cluster but better safe than sorry
     const cas = kc.clusters.map((cluster) => cluster.caFile);
-    https.globalAgent.options.ca = [];
+    https.globalAgent.options.ca = [...tls.rootCertificates]; // Add all default root certificates
     cas.forEach((ca) => {
       https.globalAgent.options.ca.push(fs.readFileSync(ca));
     });


### PR DESCRIPTION
Slipped up and didn't realize that `https.globalAgent.options.ca` actually overrides all root certificates rather than appending to them. Added all of the root certificates there as well